### PR TITLE
Adjusted to work with zsh

### DIFF
--- a/src/DeepRootVanilla/framework.sh
+++ b/src/DeepRootVanilla/framework.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-path=$(cd $(dirname $0); pwd -P)
-FRAMEWORK_FILE="${path}/Frontend/lib/deep-framework.js"
+FRAMEWORK_PATH=$(cd $(dirname $0); pwd -P)
+FRAMEWORK_FILE="${FRAMEWORK_PATH}/Frontend/lib/deep-framework.js"
 
 echo "Installing latest deep-framework from GitHub"
 curl -L -XGET https://raw.github.com/MitocGroup/deep-framework/master/src/deep-framework/browser/framework.js -o "${FRAMEWORK_FILE}" -#


### PR DESCRIPTION
In ZSH, $path is the same as $PATH, so the script fails to run. By changing the name of the variable, the script now works on ZSH, yay!
