### PR TITLE
Shellcheck Error Repairs

### DIFF
--- a/src/DeepRootVanilla/framework.sh
+++ b/src/DeepRootVanilla/framework.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-FRAMEWORK_PATH=$(cd $(dirname $0); pwd -P)
+FRAMEWORK_PATH=$(cd "$(dirname "$0")" || exit; pwd -P)
 FRAMEWORK_FILE="${FRAMEWORK_PATH}/Frontend/lib/deep-framework.js"
 
 echo "Installing latest deep-framework from GitHub"


### PR DESCRIPTION
Adjusted script to account for common shell errors.

Specifically:
- [SC2046](https://github.com/koalaman/shellcheck/wiki/SC2046): Quote to prevent word splitting (in case of dirs with spaces).
- [SC2086](https://github.com/koalaman/shellcheck/wiki/SC2086): Quote to prevent splitting (in case the filename contains spaces).
- [SC2164](https://github.com/koalaman/shellcheck/wiki/SC2164): Add exit code in case cd fails.
